### PR TITLE
Adds default mixing ratios

### DIFF
--- a/mechanisms/NO_photolysis/micm/species.json
+++ b/mechanisms/NO_photolysis/micm/species.json
@@ -12,14 +12,16 @@
       "type": "CHEM_SPEC",
       "absolute tolerance": 1e-12,
       "molecular weight [kg mol-1]": 0.044009,
-      "__is advected": false
+      "__is advected": false,
+      "__default mixing ratio [kg kg-1]": 0.0004
     },
     {
       "name": "H2O",
       "type": "CHEM_SPEC",
       "absolute tolerance": 1e-12,
       "molecular weight [kg mol-1]": 0.0180153,
-      "__is advected": false
+      "__is advected": false,
+      "__default mixing ratio [kg kg-1]": 0.0004
     },
     {
       "name": "M",
@@ -30,48 +32,55 @@
       "name": "N",
       "type": "CHEM_SPEC",
       "molecular weight [kg mol-1]": 0.028,
-      "__is advected": false
+      "__is advected": false,
+      "__default mixing ratio [kg kg-1]": 1.0e-12
     },
     {
       "name": "N2",
       "type": "CHEM_SPEC",
       "absolute tolerance": 1e-12,
       "molecular weight [kg mol-1]": 0.0280134,
-      "__is advected": false
+      "__is advected": false,
+      "__default mixing ratio [kg kg-1]": 0.74015
     },
     {
       "name": "NO",
       "type": "CHEM_SPEC",
       "molecular weight [kg mol-1]": 0.03001,
-      "__is advected": false
+      "__is advected": false,
+      "__default mixing ratio [kg kg-1]": 1.0e-9
     },
     {
       "name": "O",
       "type": "CHEM_SPEC",
       "absolute tolerance": 1e-12,
       "molecular weight [kg mol-1]": 0.0159994,
-      "__is advected": false
+      "__is advected": false,
+      "__default mixing ratio [kg kg-1]": 5.3509e-10
     },
     {
       "name": "O1D",
       "type": "CHEM_SPEC",
       "absolute tolerance": 1e-12,
       "molecular weight [kg mol-1]": 0.0159994,
-      "__is advected": false
+      "__is advected": false,
+      "__default mixing ratio [kg kg-1]": 5.3509e-10
     },
     {
       "name": "O2",
       "type": "CHEM_SPEC",
       "absolute tolerance": 1e-12,
       "molecular weight [kg mol-1]": 0.0319988,
-      "__is advected": true
+      "__is advected": true,
+      "__default mixing ratio [kg kg-1]": 0.22474
     },
     {
       "name": "O3",
       "type": "CHEM_SPEC",
       "absolute tolerance": 1e-12,
       "molecular weight [kg mol-1]": 0.0479982,
-      "__is advected": true
+      "__is advected": true,
+      "__default mixing ratio [kg kg-1]": 0.00016
     }
   ]
 }

--- a/mechanisms/chapman/micm/species.json
+++ b/mechanisms/chapman/micm/species.json
@@ -5,7 +5,8 @@
       "type": "CHEM_SPEC",
       "absolute tolerance": 1e-12,
       "molecular weight [kg mol-1]": 0.0280134,
-      "__is advected": true
+      "__is advected": true,
+      "__default mixing ratio [kg kg-1]": 0.74015
     },
     {
       "name": "M",
@@ -17,28 +18,32 @@
       "type": "CHEM_SPEC",
       "absolute tolerance": 1e-12,
       "molecular weight [kg mol-1]": 0.0159994,
-      "__is advected": false
+      "__is advected": false,
+      "__default mixing ratio [kg kg-1]": 5.3509e-10
     },
     {
       "name": "O1D",
       "type": "CHEM_SPEC",
       "absolute tolerance": 1e-12,
       "molecular weight [kg mol-1]": 0.0159994,
-      "__is advected": false
+      "__is advected": false,
+      "__default mixing ratio [kg kg-1]": 5.3509e-10
     },
     {
       "name": "O2",
       "type": "CHEM_SPEC",
       "absolute tolerance": 1e-12,
       "molecular weight [kg mol-1]": 0.0319988,
-      "__is advected": true
+      "__is advected": true,
+      "__default mixing ratio [kg kg-1]": 0.22474
     },
     {
       "name": "O3",
       "type": "CHEM_SPEC",
       "absolute tolerance": 1e-12,
       "molecular weight [kg mol-1]": 0.0479982,
-      "__is advected": true
+      "__is advected": true,
+      "__default mixing ratio [kg kg-1]": 0.00016
     }
   ]
 }

--- a/mechanisms/terminator/micm/species.json
+++ b/mechanisms/terminator/micm/species.json
@@ -5,14 +5,16 @@
       "type": "CHEM_SPEC",
       "absolute tolerance": 1e-12,
       "molecular weight [kg mol-1]": 0.035453,
-      "__is advected": true
+      "__is advected": true,
+      "__default mixing ratio [kg kg-1]": 1.0e-12
     },
     {
       "name": "Cl2",
       "type": "CHEM_SPEC",
       "absolute tolerance": 1e-12,
       "molecular weight [kg mol-1]": 0.070906,
-      "__is advected": true
+      "__is advected": true,
+      "__default mixing ratio [kg kg-1]": 1.0e-12
     }
   ]
 }


### PR DESCRIPTION
Adds default mixing ratios for the species in the Terminator and Chapman mechanisms. These are used in CAM-SIMA to set initial conditions until they can be read in from a file.